### PR TITLE
Fix maxlength bug

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -13,7 +13,7 @@ function dgi_islandora_solr_views_field_filter_admin_form($form, &$form_state) {
     '#type' => 'textfield',
     '#title' => t('Exclusion regex'),
     '#description' => t('A regular expression. Solr fields matching will be <strong>excluded</strong> from Solr Views. Leave empty to avoid filtering.'),
-    '#max_length' => 4096,
+    '#maxlength' => 4096,
     '#default_value' => variable_get('dgi_islandora_solr_views_field_filter_regex_exclude', DGI_ISLANDORA_SOLR_VIEWS_FIELD_FILTER_REGEX_EXCLUDE_DEFAULT),
     '#element_validate' => array('dgi_islandora_solr_views_field_filter_regex_element_validate'),
   );


### PR DESCRIPTION
The regex field maximum length is set with `#max_length` -- which is not an attribute that Drupal recognizes. So all regex input has been capped at 128 characters. This pull corrects it to `#maxlength`, which works.